### PR TITLE
Automatically clean LaTex project .bib files

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,70 @@ update_arxiv_if_doi: true       # Update arXiv entries with DOI information, if 
 
 
 
+### ✨ Using the `--clean-references` Feature
+
+The `--clean-references` feature automates the process of cleaning and standardizing the references in `.bib` files for your existing LaTeX projects. It scans `.tex` files for citations, matches them with entries in your `.bib` files, resolves DOIs (if available), and outputs cleaned `.bib` files with consistent formatting.
+
+This feature helps manage large reference libraries by ensuring:
+- Missing or inconsistent BibTeX entries in `.bib` files are flagged.
+- Resolved DOIs or BibTeX entries are updated and saved cleanly.
+- Outputs for resolved and unresolved references are clearly separated.
+
+---
+
+#### **Command Usage**
+
+```bash
+python cli.py --clean-references --tex-dir <path-to-tex-files> --bib-dir <path-to-bib-files> --output-dir <path-to-output>
+```
+
+#### **Arguments**
+
+| Argument       | Description                                                                                 |
+|----------------|---------------------------------------------------------------------------------------------|
+| `--tex-dir`    | Path to the directory containing `.tex` files where references (`\cite`) are located.       |
+| `--bib-dir`    | Path to the directory containing `.bib` files to be cleaned and matched.                    |
+| `--output-dir` | Path to save the cleaned references and unresolved entries.                                 |
+
+---
+
+#### **Example**
+
+```bash
+python cli.py --clean-references \
+    --tex-dir /path/to/my-latex/tex-files \
+    --bib-dir /path/to/my-latex/bib-files \
+    --output-dir /path/to/output
+```
+
+---
+
+#### **What Happens?**
+
+1. **Scans for References**:
+   - The tool scans all `.tex` files in `/path/to/my-latex/tex-files` to extract citation keys (e.g., the keys within `\cite{key}`).
+
+2. **Matches Citations**:
+   - It looks for matching entries in the `.bib` files stored in `/path/to/my-latex/bib-files`.
+
+3. **Resolves DOIs**:
+   - If a DOI (or relevant identifier) is found, it resolves it to its full BibTeX entry.
+   - Cleaned BibTeX entries are then saved in a properly formatted `.bib` file.
+
+4. **Handles Unresolved Entries**:
+   - Citation keys that cannot be matched or resolved are flagged and saved in a separate `.bib` file.
+
+5. **Generates Output**:
+   - **`references_clean.bib`**: Contains all cleaned and resolved BibTeX entries.
+   - **`references_unresolved.bib`**: Contains unresolved or unmatched entries for manual review.
+   - **`references.bib`**: Combines both resolved and unresolved entries.
+
+---
+
+
+
+
+
 ## 🦄 Features
 
 Besides the eponymous ability of resolving DOIs (and other identifiers) to BibTeX entries, this package offers a lot more features for post-processing the entries. Here are some highlights:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This feature helps manage large reference libraries by ensuring:
 #### **Command Usage**
 
 ```bash
-python cli.py --clean-references --tex-dir <path-to-tex-files> --bib-dir <path-to-bib-files> --output-dir <path-to-output>
+d2b --clean-references --tex-dir <path-to-tex-files> --bib-dir <path-to-bib-files> --output-dir <path-to-output>
 ```
 
 #### **Arguments**
@@ -125,17 +125,6 @@ python cli.py --clean-references --tex-dir <path-to-tex-files> --bib-dir <path-t
 | `--tex-dir`    | Path to the directory containing `.tex` files where references (`\cite`) are located.       |
 | `--bib-dir`    | Path to the directory containing `.bib` files to be cleaned and matched.                    |
 | `--output-dir` | Path to save the cleaned references and unresolved entries.                                 |
-
----
-
-#### **Example**
-
-```bash
-python cli.py --clean-references \
-    --tex-dir /path/to/my-latex/tex-files \
-    --bib-dir /path/to/my-latex/bib-files \
-    --output-dir /path/to/output
-```
 
 ---
 

--- a/doi2bibtex/clean.py
+++ b/doi2bibtex/clean.py
@@ -1,0 +1,137 @@
+import os
+import re
+
+from tqdm import tqdm
+
+from doi2bibtex.resolve import resolve_identifier
+
+
+def process_references(tex_dir_path,
+                       bib_dir_path,
+                       output_dir_path,
+                       config):
+    """
+    This function processes references in .tex files, matches them with DOIs or ADS codes in .bib files,
+    resolves DOIs to BibTeX entries using doi2bibtex, and creates cleaned and unresolved .bib files.
+
+    Args:
+        tex_dir_path (str): Path to the directory containing .tex files.
+        bib_dir_path (str): Path to the directory containing .bib files.
+        output_dir_path (str): Path to the output directory for saving cleaned and unresolved entries.
+
+    Returns:
+        None: Outputs relevant files to the specified directories.
+    """
+
+    # Patterns to process .tex files
+    citation_patterns = r"\\cite(?:p|t|alt)?(?:\[[^\]]*\])?(?:\[[^\]]*\])?\{([^}]*)\}"
+
+    # Initialize an empty set to store unique references
+    unique_references = set()
+
+    # Step 1: Extract unique keys from .tex files
+    for file_name in os.listdir(tex_dir_path):
+        if file_name.endswith('.tex'):
+            file_path = os.path.join(tex_dir_path, file_name)
+            with open(file_path, 'r', encoding='utf-8') as file:
+                file_content = file.read()
+                matches = re.findall(citation_patterns, file_content)
+                for match in matches:
+                    keys = [key.strip() for key in match.split(',')]
+                    unique_references.update(keys)
+
+    print(f"Total unique references: {len(unique_references)}")
+
+    # Step 2: Match keys with DOIs or ADS codes in .bib files
+    entry_pattern = r"@.*?\{(.*?),"
+    doi_pattern = r"doi\s*=\s*\{(.*?)\}"
+    ads_pattern = r"annotation\s*=\s*\{.*?ADS Bibcode:\s*([^\s,]+)"
+    key_to_doi = {}
+
+    for bib_file_name in os.listdir(bib_dir_path):
+        if bib_file_name.endswith('.bib'):
+            bib_file_path = os.path.join(bib_dir_path, bib_file_name)
+            with open(bib_file_path, 'r', encoding='utf-8') as bib_file:
+                bib_content = bib_file.read()
+                entries = bib_content.split('@')[1:]  # Skip part before the first '@'
+                entries = ['@' + entry for entry in entries]  # Add '@' back to each entry
+
+                for entry in entries:
+                    key_match = re.search(entry_pattern, entry)
+                    doi_match = re.search(doi_pattern, entry)
+                    ads_match = re.search(ads_pattern, entry) if not doi_match else None
+
+                    if key_match:
+                        key = key_match.group(1).strip()
+                        if doi_match:
+                            identifier = doi_match.group(1).strip()
+                        elif ads_match:
+                            identifier = ads_match.group(1).strip()[:-1]
+                        else:
+                            identifier = None
+
+                        if key in unique_references and identifier:
+                            key_to_doi[key] = identifier
+
+    print(f"Keys matched with DOIs: {len(key_to_doi)}")
+
+    unmatched_keys = [key for key in unique_references if key not in key_to_doi]
+    print(f"Keys without matching DOI: {unmatched_keys}")
+
+    # Step 3: Resolve DOIs using doi2bibtex
+    resolved_entries = {}
+    unresolved_keys = []
+
+    for key, doi in tqdm(key_to_doi.items(), desc="Resolving DOIs"):
+        resolved_bibtex = resolve_identifier(identifier=doi, config=config)
+        if 'There was an error:' not in resolved_bibtex:
+            resolved_bibtex = resolved_bibtex.strip()
+            resolved_bibtex = re.sub(r"@\w+\{.*?,", f"@article{{{key},", resolved_bibtex, count=1)
+            resolved_entries[key] = resolved_bibtex
+        else:
+            print(f"Could not resolve DOI for key '{key}' (DOI: {doi})")
+            unresolved_keys.append(key)
+
+    unresolved_keys.extend(unmatched_keys)
+
+    # Step 4: Retrieve unresolved original BibTeX entries
+    original_entries = {}
+    for bib_file_name in os.listdir(bib_dir_path):
+        if bib_file_name.endswith('.bib'):
+            bib_file_path = os.path.join(bib_dir_path, bib_file_name)
+            with open(bib_file_path, 'r', encoding='utf-8') as bib_file:
+                bib_content = bib_file.read()
+                entries = bib_content.split('@')[1:]  # Skip before the first '@'
+                entries = ['@' + entry for entry in entries]
+
+                for entry in entries:
+                    key_match = re.search(entry_pattern, entry)
+                    if key_match:
+                        key = key_match.group(1).strip()
+                        if key in unresolved_keys:
+                            original_entries[key] = entry.strip()
+
+    # Step 5: Save results to .bib files
+    clean_bib_file = os.path.join(output_dir_path, 'references_clean.bib')
+    unresolved_bib_file = os.path.join(output_dir_path, 'references_unresolved.bib')
+    combined_bib_file = os.path.join(output_dir_path, 'references.bib')
+
+    with open(clean_bib_file, 'w', encoding='utf-8') as clean_file:
+        for key, bibtex in resolved_entries.items():
+            clean_file.write(bibtex + '\n\n')
+
+    with open(unresolved_bib_file, 'w', encoding='utf-8') as unresolved_file:
+        for key, entry in original_entries.items():
+            unresolved_file.write(entry + '\n\n')
+
+    with open(combined_bib_file, 'w', encoding='utf-8') as combined_file:
+        for key, bibtex in resolved_entries.items():
+            combined_file.write(bibtex + '\n\n')
+        for key, entry in original_entries.items():
+            combined_file.write(entry + '\n\n')
+
+    # Summary
+    print(f"Resolved entries saved to: {clean_bib_file}")
+    print(f"Unresolved entries saved to: {unresolved_bib_file}")
+    print(f"Combined entries saved to: {combined_bib_file}")
+    print(f"Unresolved keys: {unresolved_keys}")

--- a/doi2bibtex/cli.py
+++ b/doi2bibtex/cli.py
@@ -17,6 +17,7 @@ from rich.syntax import Syntax
 from doi2bibtex import __version__
 from doi2bibtex.config import Configuration
 from doi2bibtex.resolve import resolve_identifier
+from doi2bibtex.clean import process_references
 
 
 # -----------------------------------------------------------------------------
@@ -44,6 +45,26 @@ def parse_cli_args(args: Any = None) -> Namespace:
         "--version",
         action="store_true",
         help="Print the version number and exit.",
+    )
+    parser.add_argument(
+        "--clean-references",
+        action="store_true",
+        help="Process references in .tex and .bib files and clean them.",
+    )
+    parser.add_argument(
+        "--tex-dir",
+        metavar="TEX_DIR",
+        help="Path to the directory containing .tex files (used with --clean-references).",
+    )
+    parser.add_argument(
+        "--bib-dir",
+        metavar="BIB_DIR",
+        help="Path to the directory containing .bib files (used with --clean-references).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        metavar="OUTPUT_DIR",
+        help="Path to the directory for saving cleaned and unresolved .bib files (used with --clean-references).",
     )
     parsed_args = parser.parse_args(args)
     return parsed_args
@@ -90,6 +111,28 @@ def fancy(identifier: str, config: Configuration) -> None:
     console.print("\n")
 
 
+def clean_references(tex_dir: str,
+                     bib_dir: str,
+                     output_dir: str,
+                     config) -> None:
+    """
+    Wrapper function to call the clean references functionality.
+
+    Args:
+        tex_dir (str): Path to the directory containing .tex files.
+        bib_dir (str): Path to the directory containing .bib files.
+        output_dir (str): Path to the directory for saving results.
+    """
+    if not tex_dir or not bib_dir or not output_dir:
+        raise ValueError("tex_dir, bib_dir, and output_dir must be provided"
+                         " for --clean-references.")
+
+    process_references(tex_dir_path=tex_dir,
+                       bib_dir_path=bib_dir,
+                       output_dir_path=output_dir,
+                       config=config)
+
+
 def main() -> None:  # pragma: no cover
     """
     Get identifier from the command line and resolve it.
@@ -103,6 +146,20 @@ def main() -> None:  # pragma: no cover
     if args.version:
         print(__version__)
         sys.exit(0)
+
+    # Handle clean references functionality
+    if args.clean_references:
+        try:
+            clean_references(
+                tex_dir=args.tex_dir,
+                bib_dir=args.bib_dir,
+                output_dir=args.output_dir,
+                config=config,
+            )
+            sys.exit(0)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
 
     # Either print the result as plain text, or make it fancy
     if args.plain:

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         "requests",
         "rich",
         "unidecode",
+        "tqdm",
     ],
     extras_require={
         "develop": [


### PR DESCRIPTION
Hi @timothygebhard,

if I use overleaf, I usually directly link my Zotero account. This creates very ugly .bib files, which I want to clean up in a single step.

I added the code I use in clean.py and made sure that it can be called from the command line using d2b --clean-references. For testing, I ran it only on my current project, so maybe somebody else can check if it works for them as well.

Regarding compatibility, I am not sure how other reference managers store the ADS link. Might be that this only work with Zotero for now. 

I hope this is useful for others.
Best,
Felix
