### PR TITLE
Add the first word of the paper title to the citekey

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,42 +22,6 @@ The motivation for **doi2bibtex** was rather personal and came from two facts: 1
 At some point, I got tired of the ever-growing mess of shell scripts and bash commands that I used to achieve this, and decided to re-write as a single package that would be easier to maintain and extend.
 
 
-## Why a fork?
-
-The key is FirstAuthorLastName + Year only, which means that if an author has 2 papers in the same year, they will have the same key.
-For example:
-```bash
-$ d2b --plain 10.1145/3625275.3625400
-@inproceedings{Fiedler_2023,
-  author        = {{Fiedler}, Ben and {Meier}, Roman and {Schult}, Jasmin and {Schwyn}, Daniel and {Roscoe}, Timothy},
-  title         = {Specifying the de-facto OS of a production SoC},
-  [...]
-}
-$ d2b --plain 10.1145/3593856.3595903
-@inproceedings{Fiedler_2023,
-  author        = {{Fiedler}, Ben and {Schwyn}, Daniel and {Gierczak-Galle}, Constantin and {Cock}, David and {Roscoe}, Timothy},
-  title         = {Putting out the hardware dumpster fire},
-  year          = {2023}
-  [...]
-}
-```
-
-To avoid this situation, the code is modified so that the first word of the title is appended to the key:
-```bash
-$ d2b --plain 10.1145/3625275.3625400
-@inproceedings{Fiedler_2023_Specifying,
-  author        = {{Fiedler}, Ben and {Meier}, Roman and {Schult}, Jasmin and {Schwyn}, Daniel and {Roscoe}, Timothy},
-  title         = {Specifying the de-facto OS of a production SoC},
-  [...]
-}
-$ d2b --plain 10.1145/3593856.3595903
-@inproceedings{Fiedler_2023_Putting,
-  author        = {{Fiedler}, Ben and {Schwyn}, Daniel and {Gierczak-Galle}, Constantin and {Cock}, David and {Roscoe}, Timothy},
-  title         = {Putting out the hardware dumpster fire},
-  year          = {2023}
-  [...]
-}
-```
 
 ## 🚀 Quickstart
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,42 @@ The motivation for **doi2bibtex** was rather personal and came from two facts: 1
 At some point, I got tired of the ever-growing mess of shell scripts and bash commands that I used to achieve this, and decided to re-write as a single package that would be easier to maintain and extend.
 
 
+## Why a fork?
+
+The key is FirstAuthorLastName + Year only, which means that if an author has 2 papers in the same year, they will have the same key.
+For example:
+```bash
+$ d2b --plain 10.1145/3625275.3625400
+@inproceedings{Fiedler_2023,
+  author        = {{Fiedler}, Ben and {Meier}, Roman and {Schult}, Jasmin and {Schwyn}, Daniel and {Roscoe}, Timothy},
+  title         = {Specifying the de-facto OS of a production SoC},
+  [...]
+}
+$ d2b --plain 10.1145/3593856.3595903
+@inproceedings{Fiedler_2023,
+  author        = {{Fiedler}, Ben and {Schwyn}, Daniel and {Gierczak-Galle}, Constantin and {Cock}, David and {Roscoe}, Timothy},
+  title         = {Putting out the hardware dumpster fire},
+  year          = {2023}
+  [...]
+}
+```
+
+To avoid this situation, the code is modified so that the first word of the title is appended to the key:
+```bash
+$ d2b --plain 10.1145/3625275.3625400
+@inproceedings{Fiedler_2023_Specifying,
+  author        = {{Fiedler}, Ben and {Meier}, Roman and {Schult}, Jasmin and {Schwyn}, Daniel and {Roscoe}, Timothy},
+  title         = {Specifying the de-facto OS of a production SoC},
+  [...]
+}
+$ d2b --plain 10.1145/3593856.3595903
+@inproceedings{Fiedler_2023_Putting,
+  author        = {{Fiedler}, Ben and {Schwyn}, Daniel and {Gierczak-Galle}, Constantin and {Cock}, David and {Roscoe}, Timothy},
+  title         = {Putting out the hardware dumpster fire},
+  year          = {2023}
+  [...]
+}
+```
 
 ## 🚀 Quickstart
 

--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -274,8 +274,11 @@ def generate_citekey(bibtex_dict: dict, delim: str = "_") -> dict:
     if von := first_author["von"]:
         lastname = "".join([_.title() for _ in von]) + lastname
 
-    # Combine the name and year to get the citekey
-    citekey = f"{lastname}{delim}{bibtex_dict['year']}"
+    # Add the first word of the title
+    title = bibtex_dict["title"].split(" ")[0]
+
+    # Combine the name, year and title to get the citekey
+    citekey = f"{lastname}{delim}{bibtex_dict['year']}{delim}{title}"
 
     # Update the citekey of the BibTeX entry
     bibtex_dict["ID"] = citekey

--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -6,6 +6,8 @@ Look up a BibTeX entry based on a DOI or arXiv ID.
 # IMPORTS
 # -----------------------------------------------------------------------------
 
+import re
+
 from bibtexparser.customization import splitname
 
 from doi2bibtex.ads import get_ads_bibcode_for_identifier
@@ -275,7 +277,15 @@ def generate_citekey(bibtex_dict: dict, delim: str = "_") -> dict:
         lastname = "".join([_.title() for _ in von]) + lastname
 
     # Add the first word of the title
-    title = bibtex_dict["title"].split(" ")[0]
+    articles = {"a", "the", "an"}
+    words = bibtex_dict["title"].split(" ")
+    first_non_article = next(
+        (word for word in words if word.lower() not in articles), None
+    )
+    if first_non_article is None:
+        title = "unknown"
+    else:
+        title = re.sub(r"[^a-zA-Z0-9]", "", first_non_article)
 
     # Combine the name, year and title to get the citekey
     citekey = f"{lastname}{delim}{bibtex_dict['year']}{delim}{title}"


### PR DESCRIPTION
Thank you very much for having made this tool. I am working on my own bibliography manager, and would like to integrate your tool in my process, with the following change.

Currently, the key is FirstAuthorLastName + Year only, which means that if an author has 2 papers in the same year, they will have the same key.
For example:
```bash
$ d2b --plain 10.1145/3625275.3625400
@inproceedings{Fiedler_2023,
  author        = {{Fiedler}, Ben and {Meier}, Roman and {Schult}, Jasmin and {Schwyn}, Daniel and {Roscoe}, Timothy},
  title         = {Specifying the de-facto OS of a production SoC},
  year          = {2023}
  [...]
}
$ d2b --plain 10.1145/3593856.3595903
@inproceedings{Fiedler_2023,
  author        = {{Fiedler}, Ben and {Schwyn}, Daniel and {Gierczak-Galle}, Constantin and {Cock}, David and {Roscoe}, Timothy},
  title         = {Putting out the hardware dumpster fire},
  year          = {2023}
  [...]
}
```

To avoid this situation, the code is modified so that the first word of the title is appended to the key:
```bash
$ d2b --plain 10.1145/3625275.3625400
@inproceedings{Fiedler_2023_Specifying,
  author        = {{Fiedler}, Ben and {Meier}, Roman and {Schult}, Jasmin and {Schwyn}, Daniel and {Roscoe}, Timothy},
  title         = {Specifying the de-facto OS of a production SoC},
  [...]
}
$ d2b --plain 10.1145/3593856.3595903
@inproceedings{Fiedler_2023_Putting,
  author        = {{Fiedler}, Ben and {Schwyn}, Daniel and {Gierczak-Galle}, Constantin and {Cock}, David and {Roscoe}, Timothy},
  title         = {Putting out the hardware dumpster fire},
  year          = {2023}
  [...]
}
```

### Remarks

If the same first author has 2 papers the same year with the same first word, then the `citekey`s will be similar. However this should happen rarely, so modifying the `citekey` manually is ok I believe.

One solution could be to create a hash of (some entries of) the bibtex and append it to the `citekey`.

An extension of this pull request could be to skip common words such as `the` or `a` that can appear at the beginning of the title, and use the next one.