### PR TITLE
Use the delimiter set in the config

### DIFF
--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -73,7 +73,7 @@ def postprocess_bibtex(
 
     # Generate a citekey
     if config.generate_citekey:
-        bibtex_dict = generate_citekey(bibtex_dict)
+        bibtex_dict = generate_citekey(bibtex_dict, config.citekey_delimiter)
 
     # Truncate the author list
     bibtex_dict = truncate_author_list(bibtex_dict, config)


### PR DESCRIPTION
This pull request adds the citekey delimiter set in the configuration as the second argument to `generate_citekey()` . Otherwise the delimiter is always set to `_`, regardless of the configured value.