### PR TITLE
Fix: Special characters handling and missing metadata

### DIFF
--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -83,7 +83,7 @@ def first_valid_word(sentence):
         
         # Check conditions
         if len(clean_word) > 3 and "'" not in clean_word:
-            return clean_word.lower()
+            return remove_accented_characters(clean_word.lower())
     
     # If no valid word found
     return None

--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -18,6 +18,7 @@ from doi2bibtex.utils import (
     latex_to_unicode,
     remove_accented_characters,
     latex_to_unicode,
+    html_to_unicode,
 )
 
 
@@ -62,7 +63,7 @@ def clean_html_entities(bibtex_dict: dict) -> dict:
 
     for field in text_fields:
         if field in bibtex_dict and bibtex_dict[field]:
-            bibtex_dict[field] = latex_to_unicode(bibtex_dict[field])
+            bibtex_dict[field] = html_to_unicode(bibtex_dict[field])
 
     return bibtex_dict
 

--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -18,7 +18,6 @@ from doi2bibtex.utils import (
     latex_to_unicode,
     remove_accented_characters,
     latex_to_unicode,
-    html_to_unicode,
 )
 
 
@@ -45,27 +44,6 @@ def preprocess_identifier(identifier: str) -> str:
 
     return identifier
 
-
-def clean_html_entities(bibtex_dict: dict) -> dict:
-    """
-    Decode HTML entities in all text fields of a BibTeX entry.
-
-    APIs may return text with HTML entities (e.g., &amp; instead of &).
-    This function cleans common text fields: title, booktitle, journal,
-    publisher, series, abstract, note, etc.
-    """
-    # List of fields that may contain HTML entities
-    text_fields = [
-        "title", "booktitle", "journal", "publisher", "series",
-        "abstract", "note", "address", "organization", "school",
-        "institution", "howpublished"
-    ]
-
-    for field in text_fields:
-        if field in bibtex_dict and bibtex_dict[field]:
-            bibtex_dict[field] = html_to_unicode(bibtex_dict[field])
-
-    return bibtex_dict
 
 def first_valid_word(sentence):
     """
@@ -97,9 +75,6 @@ def postprocess_bibtex(
     """
     Post-process a BibTeX entry and apply a series of fixes and tweaks.
     """
-
-    # Clean HTML entities in all text fields
-    bibtex_dict = clean_html_entities(bibtex_dict)
 
     # Fix broken ampersand in A&A journal name
     bibtex_dict = fix_broken_ampersand(bibtex_dict)
@@ -245,11 +220,20 @@ def fix_broken_ampersand(bibtex_dict: dict) -> dict:
     Fix broken ampersand in A&A journal name that we get from CrossRef.
     """
 
-    if "journal" in bibtex_dict:
-        bibtex_dict["journal"] = bibtex_dict["journal"].replace(
+    text_fields = [
+        "title", "booktitle", "journal", "publisher", "series",
+        "abstract", "note", "address", "organization", "school",
+        "institution", "howpublished"
+    ]
+
+    for text_field in text_fields:
+        if text_field not in bibtex_dict:
+            continue
+
+        bibtex_dict[text_field] = bibtex_dict[text_field].replace(
             r"{\&}amp$\mathsemicolon$", r"\&"
         )
-        bibtex_dict["journal"] = bibtex_dict["journal"].replace(
+        bibtex_dict[text_field] = bibtex_dict[text_field].replace(
             r"&amp;", r"\&"
         )
 

--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -17,7 +17,6 @@ from doi2bibtex.utils import (
     doi_to_url,
     latex_to_unicode,
     remove_accented_characters,
-    latex_to_unicode,
 )
 
 

--- a/doi2bibtex/utils.py
+++ b/doi2bibtex/utils.py
@@ -8,7 +8,6 @@ Utility functions.
 
 from pylatexenc.latex2text import LatexNodes2Text
 from unidecode import unidecode
-import html
 
 import urllib.parse
 

--- a/doi2bibtex/utils.py
+++ b/doi2bibtex/utils.py
@@ -25,7 +25,6 @@ def doi_to_url(doi: str) -> str:
     encoded_doi = urllib.parse.quote(doi, safe="")
     return f"https://doi.org/{encoded_doi}"
 
-
 def latex_to_unicode(text: str, **kwargs) -> str:
     """
     Convert LaTeX-escaped to Unicode. Example: "{\"a}" -> "ä".
@@ -41,15 +40,6 @@ def latex_to_unicode(text: str, **kwargs) -> str:
     params = {**default_params, **kwargs}
     
     return str(LatexNodes2Text(**params).latex_to_text(text))
-
-def html_to_unicode(text: dict) -> dict:
-    """
-    Convert Html-escaped to Unicode.
-    """
-    try:
-        return html.unescape(text)
-    except:
-        return text
 
 def remove_accented_characters(string: str) -> str:
     """

--- a/doi2bibtex/utils.py
+++ b/doi2bibtex/utils.py
@@ -8,6 +8,7 @@ Utility functions.
 
 from pylatexenc.latex2text import LatexNodes2Text
 from unidecode import unidecode
+import html
 
 import urllib.parse
 
@@ -32,6 +33,14 @@ def latex_to_unicode(text: str) -> str:
     """
     return str(LatexNodes2Text(math_mode='verbatim').latex_to_text(text))
 
+def latex_to_unicode(text: dict) -> dict:
+    """
+    Convert Html-escaped to Unicode.
+    """
+    try:
+        return html.unescape(text)
+    except:
+        return text
 
 def remove_accented_characters(string: str) -> str:
     """

--- a/doi2bibtex/utils.py
+++ b/doi2bibtex/utils.py
@@ -26,14 +26,23 @@ def doi_to_url(doi: str) -> str:
     return f"https://doi.org/{encoded_doi}"
 
 
-def latex_to_unicode(text: str) -> str:
+def latex_to_unicode(text: str, **kwargs) -> str:
     """
     Convert LaTeX-escaped to Unicode. Example: "{\"a}" -> "ä".
     Note: characters in math mode are *not* converted.
+    
+    Additional kwargs are passed to LatexNodes2Text.
+    Default: math_mode='verbatim' (can be overridden)
     """
-    return str(LatexNodes2Text(math_mode='verbatim').latex_to_text(text))
+    # Default parameters
+    default_params = {'math_mode': 'verbatim'}
+    
+    # Merge: kwargs override defaults
+    params = {**default_params, **kwargs}
+    
+    return str(LatexNodes2Text(**params).latex_to_text(text))
 
-def latex_to_unicode(text: dict) -> dict:
+def html_to_unicode(text: dict) -> dict:
     """
     Convert Html-escaped to Unicode.
     """

--- a/run.py
+++ b/run.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""
+Script to locally execute doi2bibtex
+Usage: python run.py <doi-ou-arxiv-id> [--plain]
+"""
+
+from doi2bibtex.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script to run all tests locally
+# NOTE: This script must be run from the project root directory
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
+pytest tests/ -v "$@"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ def test__plain(
     assert outerr.err == ""
     assert (
         outerr.out
-        == "@article{Kingma_2013,\n"
+        == "@article{Kingma_2013_autoencoding,\n"
         "  author        = {{Kingma}, Diederik P and {Welling}, Max},\n"
         "  eprint        = {1312.6114},\n"
         "  journal       = {arXiv preprints},\n"
@@ -98,7 +98,7 @@ def test__fancy(
             '',
             'BibTeX entry for identifier "1312.6114":',
             '',
-            '@article{Kingma_2013,',
+            '@article{Kingma_2013_autoencoding,',
             '  author        = {{Kingma}, Diederik P and {Welling}, Max},',
             '  eprint        = {1312.6114},',
             '  journal       = {arXiv preprints},',

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -29,7 +29,7 @@ def test__resolve_isbn_with_google_api() -> None:
     bibtex_dict = resolve_isbn_with_google_api("978-1-4008-3530-0")
     assert bibtex_dict == {
         "ENTRYTYPE": "book",
-        "ID": "Seager_2010",
+        "ID": "Seager_2010_exoplanet",
         "author": "Sara Seager",
         "isbn": "978-1-4008-3530-0",
         "publisher": "Princeton University Press",
@@ -41,7 +41,7 @@ def test__resolve_isbn_with_google_api() -> None:
     bibtex_dict = resolve_isbn_with_google_api("9780691248493")
     assert bibtex_dict == {
         "ENTRYTYPE": "book",
-        "ID": "Sinclair_2023",
+        "ID": "Sinclair_2023_birds",
         "author": (
             "Ian Sinclair and Phil Hockey and Warwick Tarboton and "
             "Niall Perrins and Dominic Rollinson and Peter Ryan"

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -100,7 +100,7 @@ def test__postprocess_bibtex(monkeypatch: pytest.MonkeyPatch) -> None:
             "year": "2019",
             "doi": "10.1103/physrevd.100.063015",
             "ENTRYTYPE": "article",
-            "ID": "Gebhard_2019",
+            "ID": "Gebhard_2019_convolutional",
         },
     )
 
@@ -263,7 +263,7 @@ def test__generate_citekey() -> None:
         "year": "1605",
     }
     bibtex_dict_2 = {
-        "ID": "DeLaMancha::1605",
+        "ID": "DeLaMancha::1605::stories",
         "ENTRYTYPE": "book",
         "author": "Don Quixote de la Mancha",
         "title": "Stories about windmills",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -78,7 +78,7 @@ def test__postprocess_bibtex(monkeypatch: pytest.MonkeyPatch) -> None:
         "url": "https://doi.org/10.1103%2Fphysrevd.100.063015",
         "doi": "10.1103/physrevd.100.063015",
         "ENTRYTYPE": "article",
-        "ID": "Gebhard_2019",
+        "ID": "Gebhard_2019_convolutionnal",
     }
 
     assert not DeepDiff(

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -103,14 +103,14 @@ def test__resolve_doi(monkeypatch: pytest.MonkeyPatch) -> None:
         resolve_doi("10.1088/1742-6596/898/7/072029"),
         {
             "journal": "Journal of Physics: Conference Series",
-            "title": "Software Quality Control at Belle {II}",
+            "title": "Software Quality Control at Belle II",
             "author": (
                 "M Ritter and T Kuhr and T Hauth and T Gebard and "
                 "M Kristof and C Pulvermacher and"
             ),
             "pages": "072029",
             "volume": "898",
-            "publisher": "{IOP} Publishing",
+            "publisher": "IOP Publishing",
             "month": "oct",
             "year": "2017",
             "url": "https://doi.org/10.1088%2F1742-6596%2F898%2F7%2F072029",
@@ -136,7 +136,7 @@ def test__resolve_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
     # Case 1: Successfully resolve an arXiv identifier
     assert (
         resolve_identifier("1312.6114", config) ==
-        "@article{Kingma_2013,\n"
+        "@article{Kingma_2013_autoencoding,\n"
         "  author        = {{Kingma}, Diederik P and {Welling}, Max},\n"
         "  eprint        = {1312.6114},\n"
         "  journal       = {arXiv preprints},\n"
@@ -148,7 +148,7 @@ def test__resolve_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
     # Case 2: Successfully resolve a DOI
     assert (
         resolve_identifier("10.1088/1742-6596/898/7/072029", config) ==
-        "@article{Ritter_2017,\n"
+        "@article{Ritter_2017_software,\n"
         "  author        = {{Ritter}, M and {Kuhr}, T and others},\n"
         "  doi           = {10.1088/1742-6596/898/7/072029},\n"
         "  journal       = {Journal of Physics: Conference Series},\n"
@@ -170,7 +170,7 @@ def test__resolve_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
     if get_ads_token(raise_on_error=False) is not None:
         assert (
             resolve_identifier("2010ApJ...721L..67R", config) ==
-            "@article{Robinson_2010,\n"
+            "@article{Robinson_2010_detecting,\n"
             "  adsnote       = {Provided by the SAO/NASA Astrophysics "
             "Data System},\n"
             "  adsurl        = {https://ui.adsabs.harvard.edu/abs/"
@@ -198,7 +198,7 @@ def test__resolve_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
     # Case 5: Resolve an ISBN
     assert (
         resolve_identifier("978-0262037310", config) ==
-        "@book{Peters_2017,\n"
+        "@book{Peters_2017_elements,\n"
         "  author        = {{Peters}, Jonas and {Janzing}, Dominik and "
         "others},\n"
         "  isbn          = {978-0262037310},\n"

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -103,14 +103,14 @@ def test__resolve_doi(monkeypatch: pytest.MonkeyPatch) -> None:
         resolve_doi("10.1088/1742-6596/898/7/072029"),
         {
             "journal": "Journal of Physics: Conference Series",
-            "title": "Software Quality Control at Belle II",
+            "title": "Software Quality Control at Belle {II}",
             "author": (
                 "M Ritter and T Kuhr and T Hauth and T Gebard and "
                 "M Kristof and C Pulvermacher and"
             ),
             "pages": "072029",
             "volume": "898",
-            "publisher": "IOP Publishing",
+            "publisher": "{IOP} Publishing",
             "month": "oct",
             "year": "2017",
             "url": "https://doi.org/10.1088%2F1742-6596%2F898%2F7%2F072029",


### PR DESCRIPTION
## Crash on missing year

### Issue 

Paper without year crash the app because on `generate_citekey` we do `bibtex_dict['year]`. But some papers does not have year metadata from crossref like this one :

> @inproceedings{XXX,                                                    
>  author        = {{Liu}, Yilin and {Chen}, Yong and {Yap}, Pew-Thian},         
>  booktitle     = {2024 ISMRM \&amp; ISMRT Annual Meeting},              
>  collection    = {ISMRM-ISMRT},                                                
>  doi           = {10.58530/2024/3559},                                         
>  issn          = {1545-4428},                                                  
>  publisher     = {ISMRM},                                                      
>  series        = {ISMRM-ISMRT},                                                
>  title         = {Scalable Zero-Shot Self-Supervised Learning for Accelerated  
>MR Fingerprinting},                                                             
>  url           = {http://dx.doi.org/10.58530/2024/3559}                        
>}     

### Fix : 

- Safe access to dictionnary : ` bibtex_dict.get('year', '')`
- Add first meaningfull title's word as element of the cietkey (i.e. `Liu_` becomes `Liu_scalable`)

## HTML entities in BibTeX entries

### Issue

- `&amp;` instead of `&` in BibTeX fields (like `booktitle`). We escape them with `fix_broken_ampersand` but only for journal   

### Fix

Add the needed fileds to the `fix_broken_ampersand` processing. `booktitle = {2024 ISMRM \&amp; ISMRT Annual Meeting} ` becomes `booktitle = {2024 ISMRM \& ISMRT Annual Meeting} `

## Tests

Handle changes in tests

