### PR TITLE
Fix config citekey delimiter no effect

### DIFF
--- a/doi2bibtex/isbn.py
+++ b/doi2bibtex/isbn.py
@@ -7,9 +7,9 @@ Resolve ISBN numbers to BibTeX entries.
 # -----------------------------------------------------------------------------
 
 import json
-
 import requests
 
+from doi2bibtex.config import Configuration
 from doi2bibtex.process import generate_citekey
 
 
@@ -17,7 +17,7 @@ from doi2bibtex.process import generate_citekey
 # DEFINITIONS
 # -----------------------------------------------------------------------------
 
-def resolve_isbn_with_google_api(isbn: str) -> dict:
+def resolve_isbn_with_google_api(isbn: str, config: Configuration) -> dict:
     """
     Resolve a given `isbn` number using the Google Books API and return
     the BibTeX entry as a dictionary.
@@ -64,6 +64,6 @@ def resolve_isbn_with_google_api(isbn: str) -> dict:
     }
 
     # Construct the citekey
-    bibtex_dict = generate_citekey(bibtex_dict)
+    bibtex_dict = generate_citekey(bibtex_dict, delim=config.citekey_delimiter)
 
     return bibtex_dict

--- a/doi2bibtex/process.py
+++ b/doi2bibtex/process.py
@@ -73,7 +73,7 @@ def postprocess_bibtex(
 
     # Generate a citekey
     if config.generate_citekey:
-        bibtex_dict = generate_citekey(bibtex_dict)
+        bibtex_dict = generate_citekey(bibtex_dict, delim=config.citekey_delimiter)
 
     # Truncate the author list
     bibtex_dict = truncate_author_list(bibtex_dict, config)

--- a/doi2bibtex/resolve.py
+++ b/doi2bibtex/resolve.py
@@ -125,7 +125,7 @@ def resolve_identifier(identifier: str, config: Configuration) -> str:
         elif is_ads_bibcode(identifier):
             bibtex_dict = resolve_ads_bibcode(identifier)
         elif is_isbn(identifier):
-            bibtex_dict = resolve_isbn_with_google_api(identifier)
+            bibtex_dict = resolve_isbn_with_google_api(identifier, config)
         else:
             raise RuntimeError(f"Unrecognized identifier: {identifier}")
 

--- a/run.py
+++ b/run.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""
+Script to locally execute doi2bibtex
+Usage: python run.py <doi-ou-arxiv-id> [--plain]
+"""
+
+from doi2bibtex.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Script to run all tests locally
+# NOTE: This script must be run from the project root directory
+
+# Get the directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
+pytest tests/ -v "$@"

--- a/tests/test_isbn.py
+++ b/tests/test_isbn.py
@@ -8,6 +8,7 @@ Unit tests for isbn.py.
 
 import pytest
 
+from doi2bibtex.config import Configuration
 from doi2bibtex.isbn import resolve_isbn_with_google_api
 
 
@@ -20,13 +21,15 @@ def test__resolve_isbn_with_google_api() -> None:
     Test `resolve_isbn_with_google_api()`.
     """
 
+    config = Configuration()
+
     # Case 1
     with pytest.raises(RuntimeError) as runtime_error:
-        resolve_isbn_with_google_api("invalid-isbn")
+        resolve_isbn_with_google_api("invalid-isbn", config)
     assert "no BibTeX entry found" in str(runtime_error)
 
     # Case 2
-    bibtex_dict = resolve_isbn_with_google_api("978-1-4008-3530-0")
+    bibtex_dict = resolve_isbn_with_google_api("978-1-4008-3530-0", config)
     assert bibtex_dict == {
         "ENTRYTYPE": "book",
         "ID": "Seager_2010",
@@ -38,7 +41,7 @@ def test__resolve_isbn_with_google_api() -> None:
     }
 
     # Case 3
-    bibtex_dict = resolve_isbn_with_google_api("9780691248493")
+    bibtex_dict = resolve_isbn_with_google_api("9780691248493", config)
     assert bibtex_dict == {
         "ENTRYTYPE": "book",
         "ID": "Sinclair_2023",


### PR DESCRIPTION
The `config` parameter is missing from functions handling `generate_citekey`, thus the delimiter set in config is not taken into account.